### PR TITLE
Add automatic datasheets

### DIFF
--- a/huggingface_datasets_converter/convert.py
+++ b/huggingface_datasets_converter/convert.py
@@ -93,7 +93,7 @@ def get_kaggle_metadata(kaggle_id):
         license = 'unknown'
 
     meta = dict(
-        name=info.get('title'),
+        dataset_name=info.get('title'),
         homepage=f"https://kaggle.com/datasets/{user}/{dataset_name}",
         description=info.get('description'),
         authors=[kaggle_username_to_markdown(user)],

--- a/huggingface_datasets_converter/convert.py
+++ b/huggingface_datasets_converter/convert.py
@@ -96,7 +96,7 @@ def get_kaggle_metadata(kaggle_id):
         dataset_name=info.get('title'),
         homepage=f"https://kaggle.com/datasets/{user}/{dataset_name}",
         description=info.get('description'),
-        authors=[kaggle_username_to_markdown(user)],
+        authors=", ".join([kaggle_username_to_markdown(user)]),
         license=license,
         citation="[More Information Needed]",
         language=None,
@@ -138,7 +138,7 @@ def kaggle_to_hf(kaggle_id, repo_id, token=None, unzip=True, path_in_repo=None):
     card = ModelCard.from_template(
         card_data=CardData(
             kaggle_id=kaggle_id,
-            licenses=[meta.license],
+            licenses=[meta.get('license')],
         ),
         template_path=TEMPLATE_DATASHEET_PATH,
         **meta,

--- a/huggingface_datasets_converter/convert.py
+++ b/huggingface_datasets_converter/convert.py
@@ -1,62 +1,147 @@
-from multiprocessing import Pool
-from functools import partial
+import json
 import os
+from functools import partial
+from multiprocessing import Pool
+from pathlib import Path
+from re import TEMPLATE
 from tempfile import TemporaryDirectory
+
+import kaggle
 import requests
 from bs4 import BeautifulSoup as bs
-import json
 from huggingface_hub import create_repo, upload_folder
-import kaggle
+from modelcards import CardData, ModelCard
 
-from .utils import download_url, download_and_extract_archive
+from .utils import download_and_extract_archive, download_url
 
-def _dl_wrap(root: str, url:str) -> None:
-    download_url(url, root)
+TEMPLATE_DATASHEET_PATH = Path(__file__).parent / "datasheet_template.md"
 
-def download_urls(urls, root='./data', num_download_workers=1):
+# Mapping from kaggle license identifiers to Hugging Face license identifiers
+kaggle_license_map = {
+    'CC0-1.0': 'cc0-1.0',
+    'CC-BY-SA-3.0': 'cc-by-sa-3.0',
+    'CC-BY-SA-4.0': 'cc-by-sa-4.0',
+    'CC-BY-NC-SA-4.0': 'cc-by-nc-sa-4.0',
+    'GPL-2.0': 'gpl-2.0',
+    'ODbL-1.0': 'odbl-1.0',
+    'DbCL-1.0': 'odbl-1.0',  # Note - this isn't exactly right, but dbcl-1.0 inherits from it.
+    'other': 'other',
+    'unknown': 'unknown',
+}
+
+
+def _dl_wrap(root: str, unzip_archives: bool, url: str) -> None:
+    if unzip_archives and os.path.basename(url).endswith('.zip'):
+        download_and_extract_archive(url, root, remove_finished=True)
+    else:
+        download_url(url, root)
+
+
+def download_urls(urls, root='./data', num_download_workers=1, unzip_archives=True):
     if not os.path.exists:
         os.makedirs(root, exist_ok=True)
     if num_download_workers == 1:
         for url in urls:
             download_url(url, root)
     else:
-        part = partial(_dl_wrap, root)
+        part = partial(_dl_wrap, root, unzip_archives)
         poolproc = Pool(num_download_workers)
         poolproc.map(part, urls)
 
-def zenodo_to_hf(zenodo_id, repo_id, num_download_workers=1):
+
+def get_bibtex_citation_from_zenodo(zenodo_id):
+    url = f'https://zenodo.org/record/{zenodo_id}/export/hx'
+    r = requests.get(url)
+    soup = bs(r.text, 'lxml')
+    citation = soup.find('pre')
+    return citation.text
+
+
+def get_zenodo_metadata(zenodo_id):
     url = f'https://zenodo.org/record/{zenodo_id}'
     r = requests.get(url, headers={'Accept': 'application/json'})
     soup = bs(r.text, 'lxml')
     json_str = soup.find('script').text
-    zenodo_record_data = json.loads(json_str)
-    
-    zenodo_files = zenodo_record_data.get('distribution')
-    urls_to_download = [x['contentUrl'] for x in zenodo_files]
+    data = json.loads(json_str)
+    meta = dict(
+        dataset_name=data.get('name'),
+        authors=", ".join([x.get('name') for x in data.get('creator')]),
+        description=data.get('description'),
+        language=data.get('inLanguage').get('name'),  # Ex. 'English'. will have to be converted to HF taxonomy ('en')
+        license=data.get('license'),  # Returns a URL: http://creativecommons.org/licenses/by-nc/2.0/
+        homepage=data.get('url'),
+        citation=get_bibtex_citation_from_zenodo(zenodo_id),
+        zenodo_id=zenodo_id,
+        zenodo_files=[x.get('contentUrl') for x in data.get('distribution')],
+    )
+    # meta['language'] = languages_map.get(meta['language'])
+    return meta
 
+
+def kaggle_username_to_markdown(username):
+    return f"[@{username}](https://kaggle.com/{username})"
+
+
+def get_kaggle_metadata(kaggle_id):
+    user, dataset_name = kaggle_id.split('/')
+    data = kaggle.api.metadata_get(user, dataset_name)
+    info = data['info']
+    try:
+        license_kaggle = data['info']['licenses'][0].get('name')
+        license = kaggle_license_map.get(license_kaggle, 'unknown')
+    except:
+        license = 'unknown'
+
+    meta = dict(
+        name=info.get('title'),
+        homepage=f"https://kaggle.com/datasets/{user}/{dataset_name}",
+        description=info.get('description'),
+        authors=[kaggle_username_to_markdown(user)],
+        license=license,
+        citation="[More Information Needed]",
+        language=None,
+        kaggle_id=kaggle_id,
+    )
+    return meta
+
+
+def zenodo_to_hf(zenodo_id, repo_id, num_download_workers=1, unzip_archives=True):
+    meta = get_zenodo_metadata(zenodo_id)
+    urls_to_download = meta.pop('zenodo_files')
     with TemporaryDirectory() as temp_dir:
-        download_urls(urls_to_download, temp_dir, num_download_workers)
+        download_urls(urls_to_download, temp_dir, num_download_workers, unzip_archives)
         url = create_repo(repo_id, repo_type='dataset', exist_ok=True)
-        upload_folder(
-            folder_path=temp_dir,
-            path_in_repo="",
-            repo_id=repo_id,
-            token=None,
-            repo_type='dataset'
-        )
+        upload_folder(folder_path=temp_dir, path_in_repo="", repo_id=repo_id, token=None, repo_type='dataset')
+
+    # Try to make dataset card as well!
+    card = ModelCard.from_template(
+        card_data=CardData(
+            zenodo_id=zenodo_id,
+            licenses=['unknown'],
+        ),
+        template_path=TEMPLATE_DATASHEET_PATH,
+        **meta,
+    )
+    card.push_to_hub(repo_id, repo_type='dataset')
+
     print(f"Uploaded your files. Check it out here: {url}")
 
 
 def kaggle_to_hf(kaggle_id, repo_id, token=None, unzip=True, path_in_repo=None):
     path_in_repo = path_in_repo or ""
+    meta = get_kaggle_metadata(kaggle_id)
     with TemporaryDirectory() as temp_dir:
         kaggle.api.dataset_download_files(kaggle_id, temp_dir, unzip=unzip, quiet=False)
         url = create_repo(repo_id, repo_type='dataset', exist_ok=True)
-        upload_folder(
-            folder_path=temp_dir,
-            path_in_repo="",
-            repo_id=repo_id,
-            token=None,
-            repo_type='dataset'
-        )
+        upload_folder(folder_path=temp_dir, path_in_repo="", repo_id=repo_id, token=None, repo_type='dataset')
+    # Try to make dataset card as well!
+    card = ModelCard.from_template(
+        card_data=CardData(
+            kaggle_id=kaggle_id,
+            licenses=[meta.license],
+        ),
+        template_path=TEMPLATE_DATASHEET_PATH,
+        **meta,
+    )
+    card.push_to_hub(repo_id, repo_type='dataset')
     print(f"Uploaded your files. Check it out here: {url}")

--- a/huggingface_datasets_converter/datasheet_template.md
+++ b/huggingface_datasets_converter/datasheet_template.md
@@ -1,0 +1,128 @@
+---
+{{ card_data }}
+---
+
+# Dataset Card for {{ dataset_name }}
+
+## Table of Contents
+- [Table of Contents](#table-of-contents)
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks and Leaderboards](#supported-tasks-and-leaderboards)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits](#data-splits)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+  - [Contributions](#contributions)
+
+## Dataset Description
+
+- **Homepage:** {{ homepage }}
+- **Repository:**
+- **Paper:**
+- **Leaderboard:**
+- **Point of Contact:**
+
+### Dataset Summary
+
+{{ description }}
+
+### Supported Tasks and Leaderboards
+
+[More Information Needed]
+
+### Languages
+
+{{ "The class labels in the dataset are in " + language if language else "[More Information Needed]" }}
+
+## Dataset Structure
+
+### Data Instances
+
+[More Information Needed]
+
+### Data Fields
+
+[More Information Needed]
+
+### Data Splits
+
+[More Information Needed]
+
+## Dataset Creation
+
+### Curation Rationale
+
+[More Information Needed]
+
+### Source Data
+
+#### Initial Data Collection and Normalization
+
+[More Information Needed]
+
+#### Who are the source language producers?
+
+[More Information Needed]
+
+### Annotations
+
+#### Annotation process
+
+[More Information Needed]
+
+#### Who are the annotators?
+
+[More Information Needed]
+
+### Personal and Sensitive Information
+
+[More Information Needed]
+
+## Considerations for Using the Data
+
+### Social Impact of Dataset
+
+[More Information Needed]
+
+### Discussion of Biases
+
+[More Information Needed]
+
+### Other Known Limitations
+
+[More Information Needed]
+
+## Additional Information
+
+### Dataset Curators
+
+This dataset was shared by {{ authors }}
+
+### Licensing Information
+
+{{ "The license for this dataset is " + license if license else "[More Information Needed]" }}
+
+### Citation Information
+
+```bibtex
+{{ citation }}
+```
+
+### Contributions
+
+[More Information Needed]

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ huggingface_hub==0.8.1
 kaggle
 lxml
 Pillow
-git+https://github.com/nateraw/modelcards@main
+modelcards==0.1.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ huggingface_hub==0.8.1
 kaggle
 lxml
 Pillow
+git+https://github.com/nateraw/modelcards@main


### PR DESCRIPTION
This PR adds feature where we gather metadata from the source dataset + try to automatically generate a data card, which we also push when uploading. It uses the main branch of `modelcards` for now, but will try to make a release so we don't have to do that.

Resolves #3 