### PR TITLE
Add new licenses and declare all datasets are allowed

### DIFF
--- a/huggingface_datasets_converter/convert.py
+++ b/huggingface_datasets_converter/convert.py
@@ -17,6 +17,7 @@ TEMPLATE_DATASHEET_PATH = Path(__file__).parent / "datasheet_template.md"
 
 # Mapping from kaggle license identifiers to Hugging Face license identifiers
 # Note: all licenses in datasets inside Kaggle allow re-sharing of datasets; what we are doing here.
+# When license is not specified or is 'other' then re-sharing is not allowed.
 kaggle_license_map = {
     'CC0-1.0': 'cc0-1.0',
     'CC-BY-SA-3.0': 'cc-by-sa-3.0',

--- a/huggingface_datasets_converter/convert.py
+++ b/huggingface_datasets_converter/convert.py
@@ -16,12 +16,16 @@ from .utils import download_and_extract_archive, download_url
 TEMPLATE_DATASHEET_PATH = Path(__file__).parent / "datasheet_template.md"
 
 # Mapping from kaggle license identifiers to Hugging Face license identifiers
+# Note: all licenses in datasets inside Kaggle allow re-sharing of datasets; what we are doing here.
 kaggle_license_map = {
     'CC0-1.0': 'cc0-1.0',
     'CC-BY-SA-3.0': 'cc-by-sa-3.0',
     'CC-BY-SA-4.0': 'cc-by-sa-4.0',
     'CC-BY-NC-SA-4.0': 'cc-by-nc-sa-4.0',
     'GPL-2.0': 'gpl-2.0',
+    'GPL-3.0': 'gpl-3.0',
+    'ODC Public Domain Dedication and Licence (PDDL)': 'pddl',
+    'ODC Attribution License (ODC-By)': 'odc-by',
     'ODbL-1.0': 'odbl-1.0',
     'DbCL-1.0': 'odbl-1.0',  # Note - this isn't exactly right, but dbcl-1.0 inherits from it.
     'other': 'other',

--- a/huggingface_datasets_converter/convert.py
+++ b/huggingface_datasets_converter/convert.py
@@ -96,6 +96,14 @@ def get_kaggle_metadata(kaggle_id):
     except:
         license = 'unknown'
 
+    if license == 'unknown':
+        raise NameError(
+            f"The license of the {kaggle_id} dataset is unknown."
+            " No one can use, share, distribute, re-post, add to,"
+            " transform or change the dataset if it has not a specified"
+            " a license."
+        )
+
     meta = dict(
         dataset_name=info.get('title'),
         homepage=f"https://kaggle.com/datasets/{user}/{dataset_name}",

--- a/huggingface_datasets_converter/convert.py
+++ b/huggingface_datasets_converter/convert.py
@@ -100,10 +100,12 @@ def get_kaggle_metadata(kaggle_id):
 
     if license == 'unknown' or license == 'other':
         raise NameError(
-            f"The license of the {kaggle_id} dataset is unknown."
+            f"The license of the {kaggle_id} dataset is unknown or is not supported in the Hugging Face Hub."
             " No one can use, share, distribute, re-post, add to,"
             " transform or change the dataset if it has not a specified"
-            " a license."
+            " a license. You can ask the dataset author to specify a"
+            " license in the 'Discussion' section of the dataset's"
+            " Kaggle page."
         )
 
     meta = dict(

--- a/huggingface_datasets_converter/convert.py
+++ b/huggingface_datasets_converter/convert.py
@@ -16,15 +16,16 @@ from .utils import download_and_extract_archive, download_url
 TEMPLATE_DATASHEET_PATH = Path(__file__).parent / "datasheet_template.md"
 
 # Mapping from kaggle license identifiers to Hugging Face license identifiers
-# Note: all licenses in datasets inside Kaggle allow re-sharing of datasets; what we are doing here.
-# When license is not specified or is 'other' then re-sharing is not allowed.
+# Note: all Kaggle dataset licenses allow re-sharing of datasets, which is required to use this tool.
+# When license is not specified or is 'other', then re-sharing is not allowed and thus this tool will fail.
 kaggle_license_map = {
     'CC0-1.0': 'cc0-1.0',
     'CC-BY-SA-3.0': 'cc-by-sa-3.0',
     'CC-BY-SA-4.0': 'cc-by-sa-4.0',
     'CC-BY-NC-SA-4.0': 'cc-by-nc-sa-4.0',
     'GPL-2.0': 'gpl-2.0',
-    'GPL-3.0': 'gpl-3.0',
+    'GNU Lesser General Public License 3.0': 'lgpl-3.0',
+    'GNU Affero General Public License 3.0': 'agpl-3.0',
     'ODC Public Domain Dedication and Licence (PDDL)': 'pddl',
     'ODC Attribution License (ODC-By)': 'odc-by',
     'ODbL-1.0': 'odbl-1.0',

--- a/huggingface_datasets_converter/convert.py
+++ b/huggingface_datasets_converter/convert.py
@@ -96,7 +96,7 @@ def get_kaggle_metadata(kaggle_id):
     except:
         license = 'unknown'
 
-    if license == 'unknown':
+    if license == 'unknown' or license == 'other':
         raise NameError(
             f"The license of the {kaggle_id} dataset is unknown."
             " No one can use, share, distribute, re-post, add to,"


### PR DESCRIPTION
- Added three licenses: `'GPL-3.0', 'ODC Public Domain Dedication and Licence (PDDL)', 'ODC Attribution License (ODC-By)'`.
- Review that all licenses in Kaggle allow for redistribution thus, we are safe to go.
- Send an error when the license is `unknown` or `other`