### PR TITLE
Fix token passing

### DIFF
--- a/huggingface_datasets_converter/convert.py
+++ b/huggingface_datasets_converter/convert.py
@@ -214,7 +214,7 @@ def kaggle_to_hf(kaggle_id, repo_id, token=None, unzip=True, path_in_repo=None):
         gitattributes_file.write_text(_gitattributes_text)
         upload_file(path_or_fileobj=gitattributes_file.as_posix(), path_in_repo=".gitattributes", repo_id=repo_id, token=token, repo_type='dataset')
 
-        upload_folder(folder_path=temp_dir, path_in_repo="", repo_id=repo_id, token=None, repo_type='dataset')
+        upload_folder(folder_path=temp_dir, path_in_repo="", repo_id=repo_id, token=token, repo_type='dataset')
     # Try to make dataset card as well!
     card = DatasetCard.from_template(
         card_data=DatasetCardData(

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 bs4
 datasets
-huggingface_hub
+git+https://github.com/huggingface/huggingface_hub
 kaggle
 lxml
 Pillow

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 bs4
 datasets
-git+https://github.com/huggingface/huggingface_hub
+huggingface_hub
 kaggle
 lxml
 Pillow


### PR DESCRIPTION
Resolves #17. The token was set to `None` so I repeatedly got 401 while trying to push to Hub through converter.